### PR TITLE
fix: use :live_mode as default environment fallback

### DIFF
--- a/lib/dodopayments/client.rb
+++ b/lib/dodopayments/client.rb
@@ -129,7 +129,7 @@ module Dodopayments
       initial_retry_delay: self.class::DEFAULT_INITIAL_RETRY_DELAY,
       max_retry_delay: self.class::DEFAULT_MAX_RETRY_DELAY
     )
-      base_url ||= Dodopayments::Client::ENVIRONMENTS.fetch(environment&.to_sym || :production) do
+      base_url ||= Dodopayments::Client::ENVIRONMENTS.fetch(environment&.to_sym || :live_mode) do
         message = "environment must be one of #{Dodopayments::Client::ENVIRONMENTS.keys}, got #{environment}"
         raise ArgumentError.new(message)
       end


### PR DESCRIPTION
## Summary

- Fixes CI test failure in `test_raises_on_missing_non_nullable_opts` caused by incorrect default environment key
- The `ENVIRONMENTS` hash contains `:live_mode` and `:test_mode`, but the fallback when no environment is specified was `:production` (which doesn't exist), causing an "environment must be one of" error to be raised before the `bearer_token` validation could run
- Changed the default fallback from `:production` to `:live_mode` to match the actual `ENVIRONMENTS` keys

## Test Results

All 169 tests pass locally with 0 failures after the fix.